### PR TITLE
Use correct library.properties architectures value

### DIFF
--- a/libraries/EEPROM/library.properties
+++ b/libraries/EEPROM/library.properties
@@ -6,5 +6,5 @@ sentence=Enables reading and writing to the permanent board storage.
 paragraph=This library allows to read and write data in a memory type, the EEPROM, that keeps its content also when the board is powered off. The amount of EEPROM available depends on the microcontroller type.
 category=Data Storage
 url=http://www.arduino.cc/en/Reference/EEPROM
-architectures=avr
+architectures=megaavr
 

--- a/libraries/HID/library.properties
+++ b/libraries/HID/library.properties
@@ -6,4 +6,4 @@ sentence=Module for PluggableUSB infrastructure. Exposes an API for devices like
 paragraph=
 category=Communication
 url=http://www.arduino.cc/en/Reference/HID
-architectures=avr
+architectures=megaavr

--- a/libraries/SPI/library.properties
+++ b/libraries/SPI/library.properties
@@ -6,5 +6,5 @@ sentence=Enables the communication with devices that use the Serial Peripheral I
 paragraph=SPI is a synchronous serial data protocol used by microcontrollers for communicating with one or more peripheral devices quickly over short distances. It uses three lines common to all devices (MISO, MOSI and SCK) and one specific for each device.
 category=Communication
 url=http://www.arduino.cc/en/Reference/SPI
-architectures=avr
+architectures=megaavr
 

--- a/libraries/SoftwareSerial/library.properties
+++ b/libraries/SoftwareSerial/library.properties
@@ -6,5 +6,5 @@ sentence=Enables serial communication on any digital pin.
 paragraph=The SoftwareSerial library has been developed to allow serial communication on any digital pin of the board, using software to replicate the functionality of the hardware UART. It is possible to have multiple software serial ports with speeds up to 115200 bps. 
 category=Communication
 url=http://www.arduino.cc/en/Reference/SoftwareSerial
-architectures=avr
+architectures=megaavr
 

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -6,5 +6,5 @@ sentence=This library allows you to communicate with I2C and Two Wire Interface 
 paragraph=It allows the communication with I2C devices like temperature sensors, realtime clocks and many others using SDA (Data Line) and SCL (Clock Line).
 category=Communication
 url=http://www.arduino.cc/en/Reference/Wire
-architectures=avr
+architectures=megaavr
 


### PR DESCRIPTION
The previous `avr` architectures value in the library.properties metadata files of the bundled libraries causes warnings to be displayed during compilation:
```
WARNING: library SPI claims to run on (avr) architecture(s) and may be incompatible with your current board which runs on (megaavr) architecture(s).
```

Originally reported at http://forum.arduino.cc/index.php?topic=579079

CC: @sandeepmistry