### PR TITLE
Flashing during startup using LED_BUILTIN as a way to debug if the boot loader is working

### DIFF
--- a/variants/uno2018/variant.c
+++ b/variants/uno2018/variant.c
@@ -111,4 +111,13 @@ void initVariant() {
 	// IMU SS HIGH by default
 	pinMode(SPIIMU_SS, OUTPUT);
 	digitalWrite(SPIIMU_SS, HIGH);
+	
+	pinMode(LED_BUILTIN, OUTPUT);
+	//BLINK THE LED 3 TIMES (JUST AS THE UNO DOES)
+	for(int i=0;i<3;i++){
+		digitalWrite(LED_BUILTIN, HIGH);
+		delay(100);
+		digitalWrite(LED_BUILTIN, LOW);
+		delay(100);
+	}
 }


### PR DESCRIPTION
Within the Optiboot and ATmega bootloader, there was a way to see if the bootloader was running correctly.
As a hobbyist, it is a good way to debug that your chip isn't burned, and it's good for consistency between the UNO and the UNO wifi rev2.

The LED_BUILTIN is not connected to any pin header so it wouldn't interfere with external components, like what happened when the pin 13 was the internal LED (see this https://arduino.stackexchange.com/questions/22165/pin-13-fires-relay-when-powering-on-how-to-disable )

Especially since the Arduino focussed at beginners and schools I think it is good to have as much feedback coming from the device as possible (in an easy way to check if the board is working), because there is always the risk of students (and makers) breaking boards in creative ways.

I checked the code just with some simple sketches, I didn't check if it influences the communication to the NINA chip. 

Right now I used the arbitrary number of 3 flashes, but it would be better to do something to see if the Serial communication is connected ( + 1), NINA is connected and working  ( + 1) and one 'standard' flash to see if the board is started.

Some potential proposal:

1. Flash: Means board started running
2. Flash: Means board is connected to NINA (and powered by VCC)
3. Flash: Means board is connected to NINA and Serial is connected