### PR TITLE
Changed operator bool to explicit rather than implicit conversion in Serial

### DIFF
--- a/cores/arduino/UART.h
+++ b/cores/arduino/UART.h
@@ -164,7 +164,7 @@ class UartClass : public HardwareSerial
     inline size_t write(unsigned int n) { return write((uint8_t)n); }
     inline size_t write(int n) { return write((uint8_t)n); }
     using Print::write; // pull in write(str) and write(buf, size) from Print
-    operator bool() { return true; }
+    explicit operator bool() { return true; }
 
     // Interrupt handlers - Not intended to be called externally
     inline void _rx_complete_irq(void);

--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -103,7 +103,7 @@ public:
   virtual int read();
   virtual int available();
   virtual void flush();
-  operator bool() { return true; }
+  explicit operator bool() { return true; }
   
   using Print::write;
 


### PR DESCRIPTION
In the file
SoftwareSerial.h and UART.h
If you were to notice that in every Serial based Class we have a function with the type
`operator bool() { return true; }` 

By writing explicit, we can ensure that there is no form of implicit conversion or otherwise.
For further details view https://stackoverflow.com/questions/39995573/when-can-i-use-explicit-operator-bool-without-a-cast

This would ensure that `bool b = Serial1; `would not result in b getting a value

For example, comparing the following codes:-
```
struct T {
    operator bool() const { return true; }
};
int main()
{
    T t;
    bool B = t; // Okay
}
```
Does not result in an error due to an absence of explicit.
However, adding explicit we get an error that the conversion cannot be performed in the following sample.

```
struct T {
    explicit operator bool() const { return true; }
};
int main()
{
    T t;
    bool B = t; // error cannot convert t from bool
}
```

An Operator bool with explicit would render it compatible with [only these statements](https://stackoverflow.com/a/39995574)

For example
```
while(Serial);
if(Serial)
for(;Serial;)
```

**CONSTEXPR**

Further, I have marked these statements as `constexpr `given they indeed are constant compile time expressions and their values will not change dynamically at runtime