### PR TITLE
Corrected TwoWire::onRequestService(void) to correctly reset the write buffer before send frame.

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -341,10 +341,8 @@ void TwoWire::onRequestService(void)
 		return;
 	}
 	
-	// reset tx buffer iterator vars
-	// !!! this will kill any pending pre-master sendTo() activity
-	txBufferIndex = 0;
-	txBufferLength = 0;
+	// reset slave buffer iterator var
+	slave_bytesToWrite = 0;
   
 	// alert user program
 	user_onRequest();

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -341,7 +341,7 @@ void TwoWire::onRequestService(void)
 		return;
 	}
 	
-	// reset slave buffer iterator var
+	// reset slave write buffer iterator var
 	slave_bytesToWrite = 0;
   
 	// alert user program


### PR DESCRIPTION
Hi!

txBufferIndex and txBufferLength is used in TwoWire::write(uint8_t data) of the original ATMEGA328p Wire library for control the iteration of write buffer...

...but no longer control the buffer since TwoWire::write(uint8_t data) is modified for run with megaavr architecture (the new variable for control it is slave_bytesToWrite).

I've modified TwoWire::onRequestService(void) for reset correctly the buffer before than the slave send his datas.

---

This sample code slave side shows the problem:  (in using the ATMEGA4809 chip from Arduino Uno WiFi Rev2)
```
#include <Wire.h>

void setup() {
  Wire.begin(0x10);
  Wire.onRequest(reqIRQ);
}

void loop() {
  delay(1000);
}

void reqIRQ() {
  Wire.write(0x01);
  Wire.write(0x02);
  Wire.write(0x03);
}
```

1st read on master at 0x10 address:
```
0x01
0x02
0x03
```

2nd read on master at 0x10 address:
```
0x01
0x02
0x03
0x01
0x02
0x03
```

3th read on master at 0x10 address:
```
0x01
0x02
0x03
0x01
0x02
0x03
0x01
0x02
0x03
```
 etc.