### PR TITLE
Added SAMPCAP flag to analogRead()

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -38,7 +38,7 @@ void analogReference(uint8_t mode)
 	if((mode == EXTERNAL) || (mode == VDD)) {
 
 		/* Set reference in ADC peripheral */
-		ADC0.CTRLC |= mode;
+		ADC0.CTRLC |= mode | ADC_SAMPCAP_bm;
 
 	/* If reference using internal reference from VREF */
 	} else if (


### PR DESCRIPTION
According to [datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/48-pin-Data-Sheet-megaAVR-0-series-DS40002016B.pdf)  at page 25 SAMPCAP should be set to 1 for VREF > 1.1V