### PR TITLE
Remove very bad loop in Serial transmit driver that causes the CPU

### DIFF
--- a/cores/arduino/UART.cpp
+++ b/cores/arduino/UART.cpp
@@ -88,7 +88,6 @@ void serialEventRun(void)
 void UartClass::_tx_data_empty_irq(void)
 {
     // Check if tx buffer already empty.
-    // This interrupt-handler can be called "manually" from flush();
     if (_tx_buffer_head == _tx_buffer_tail) {
         // Buffer empty, so disable "data register empty" interrupt
         (*_hwserial_module).CTRLA &= (~USART_DREIE_bm);

--- a/cores/arduino/UART.cpp
+++ b/cores/arduino/UART.cpp
@@ -107,8 +107,6 @@ void UartClass::_tx_data_empty_irq(void)
 
     (*_hwserial_module).TXDATAL = c;
 
-    while(!((*_hwserial_module).STATUS & USART_DREIF_bm));
-
     if (_tx_buffer_head == _tx_buffer_tail) {
         // Buffer empty, so disable "data register empty" interrupt
         (*_hwserial_module).CTRLA &= (~USART_DREIE_bm);

--- a/cores/arduino/UART.cpp
+++ b/cores/arduino/UART.cpp
@@ -119,17 +119,18 @@ void UartClass::_tx_data_empty_irq(void)
 }
 
 // To invoke data empty "interrupt" via a call, use this method
-void UartClass::_poll_tx_data_empty(void) {
+void UartClass::_poll_tx_data_empty(void)
+{
     if ( (!(SREG & CPU_I_bm)) || (!((*_hwserial_module).CTRLA & USART_DREIE_bm)) ) {
-	// Interrupts are disabled either globally or for data register empty,
-	// so we'll have to poll the "data register empty" flag ourselves.
-	// If it is set, pretend an interrupt has happened and call the handler
-	//to free up space for us.
+        // Interrupts are disabled either globally or for data register empty,
+        // so we'll have to poll the "data register empty" flag ourselves.
+        // If it is set, pretend an interrupt has happened and call the handler
+        //to free up space for us.
 
-	// Invoke interrupt handler only if conditions data register is empty
-	if ((*_hwserial_module).STATUS & USART_DREIF_bm) {
-	    _tx_data_empty_irq();
-	}
+        // Invoke interrupt handler only if conditions data register is empty
+        if ((*_hwserial_module).STATUS & USART_DREIF_bm) {
+            _tx_data_empty_irq();
+        }
     }
     // In case interrupts are enabled, the interrupt routine will be invoked by itself
 }
@@ -266,7 +267,7 @@ void UartClass::flush()
 
         // If interrupts are globally disabled or the and DR empty interrupt is disabled,
         // poll the "data register empty" interrupt flag to prevent deadlock
-	_poll_tx_data_empty();
+        _poll_tx_data_empty();
     }
     // If we get here, nothing is queued anymore (DREIE is disabled) and
     // the hardware finished transmission (TXCIF is set).
@@ -307,7 +308,7 @@ size_t UartClass::write(uint8_t c)
     //If the output buffer is full, there's nothing for it other than to
     //wait for the interrupt handler to empty it a bit (or emulate interrupts)
     while (i == _tx_buffer_tail) {
-	_poll_tx_data_empty();
+        _poll_tx_data_empty();
     }
 
     _tx_buffer[_tx_buffer_head] = c;

--- a/cores/arduino/UART.cpp
+++ b/cores/arduino/UART.cpp
@@ -119,7 +119,7 @@ void UartClass::_tx_data_empty_irq(void)
 }
 
 // To invoke data empty "interrupt" via a call, use this method
-void UartClass::_tx_data_empty_soft(void) {
+void UartClass::_poll_tx_data_empty(void) {
     if ( (!(SREG & CPU_I_bm)) || (!((*_hwserial_module).CTRLA & USART_DREIE_bm)) ) {
 	// Interrupts are disabled either globally or for data register empty,
 	// so we'll have to poll the "data register empty" flag ourselves.
@@ -266,7 +266,7 @@ void UartClass::flush()
 
         // If interrupts are globally disabled or the and DR empty interrupt is disabled,
         // poll the "data register empty" interrupt flag to prevent deadlock
-	_tx_data_empty_soft();
+	_poll_tx_data_empty();
     }
     // If we get here, nothing is queued anymore (DREIE is disabled) and
     // the hardware finished transmission (TXCIF is set).
@@ -307,7 +307,7 @@ size_t UartClass::write(uint8_t c)
     //If the output buffer is full, there's nothing for it other than to
     //wait for the interrupt handler to empty it a bit (or emulate interrupts)
     while (i == _tx_buffer_tail) {
-	_tx_data_empty_soft();
+	_poll_tx_data_empty();
     }
 
     _tx_buffer[_tx_buffer_head] = c;

--- a/cores/arduino/UART.h
+++ b/cores/arduino/UART.h
@@ -170,7 +170,7 @@ class UartClass : public HardwareSerial
     inline void _rx_complete_irq(void);
     void _tx_data_empty_irq(void);
   private:
-    void _tx_data_empty_soft(void);
+    void _poll_tx_data_empty(void);
 };
 
 #if defined(HWSERIAL0)

--- a/cores/arduino/UART.h
+++ b/cores/arduino/UART.h
@@ -169,6 +169,8 @@ class UartClass : public HardwareSerial
     // Interrupt handlers - Not intended to be called externally
     inline void _rx_complete_irq(void);
     void _tx_data_empty_irq(void);
+  private:
+    void _tx_data_empty_soft(void);
 };
 
 #if defined(HWSERIAL0)


### PR DESCRIPTION
Remove very bad loop in Serial transmit driver that causes the CPU
to spend most of its time looping in the interrupt driver, entirely
locking out other operations and also causing incoming data on other
Serial ports to be lost.