### PR TITLE
Fix bug in baudrate compensation.

### DIFF
--- a/cores/arduino/UART.cpp
+++ b/cores/arduino/UART.cpp
@@ -149,7 +149,7 @@ void UartClass::begin(unsigned long baud, uint16_t config)
 
     int8_t sigrow_val = SIGROW.OSC16ERR5V;
     baud_setting *= (1024 + sigrow_val);
-    baud_setting /= (1024 - abs(sigrow_val));
+    baud_setting /= 1024;
 
     // assign the baud_setting, a.k.a. BAUD (USART Baud Rate Register)
     (*_hwserial_module).BAUD = (int16_t) baud_setting;

--- a/cores/arduino/UART.cpp
+++ b/cores/arduino/UART.cpp
@@ -140,7 +140,7 @@ void UartClass::begin(unsigned long baud, uint16_t config)
     uint8_t oldSREG = SREG;
     cli();
 
-    baud_setting = (((8 * F_CPU_CORRECTED) / baud) + 1) / 2;
+    baud_setting = (((8 * F_CPU) / baud) + 1) / 2;
     // Disable CLK2X
     (*_hwserial_module).CTRLB &= (~USART_RXMODE_CLK2X_gc);
     (*_hwserial_module).CTRLB |= USART_RXMODE_NORMAL_gc;

--- a/cores/arduino/UART.cpp
+++ b/cores/arduino/UART.cpp
@@ -148,8 +148,7 @@ void UartClass::begin(unsigned long baud, uint16_t config)
     _written = false;
 
     int8_t sigrow_val = SIGROW.OSC16ERR5V;
-    baud_setting *= (1024 + sigrow_val);
-    baud_setting /= 1024;
+    baud_setting += (baud_setting * sigrow_val) / 1024;
 
     // assign the baud_setting, a.k.a. BAUD (USART Baud Rate Register)
     (*_hwserial_module).BAUD = (int16_t) baud_setting;


### PR DESCRIPTION
The code is now in accordance to the data sheet. The previous code would in effect either apply twice the compensation, or apply no compensation, depending on the polarity of
the compensation.
For how to correctly calculate baudrate compensation, see for instance the megaAVR 0-Series Manual chapter 9.3.4.1

I have verified this by running this program: https://github.com/arduino/ArduinoCore-megaavr/files/3461514/Test_serial_bug.txt
It allows one to verify the exact baudrate with a frequency counter. With the correct code, the error I recorded with my sample was 0,15%. With the original code, 0,3%-