### PR TITLE
Remove PROGMEM attributes and pgm_read_byte

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -86,10 +86,10 @@ unsigned long microsecondsToClockCycles(unsigned long microseconds);
 // Get the bit location within the hardware port of the given virtual pin.
 // This comes from the pins_*.c file for the active board configuration.
 
-extern const uint8_t PROGMEM digital_pin_to_port[];
-extern const uint8_t PROGMEM digital_pin_to_bit_mask[];
-extern const uint8_t PROGMEM digital_pin_to_bit_position[];
-extern const uint8_t PROGMEM digital_pin_to_timer[];
+extern const uint8_t digital_pin_to_port[];
+extern const uint8_t digital_pin_to_bit_mask[];
+extern const uint8_t digital_pin_to_bit_position[];
+extern const uint8_t digital_pin_to_timer[];
 
 // Get the bit location within the hardware port of the given virtual pin.
 // This comes from the pins_*.c file for the active board configuration.
@@ -118,12 +118,12 @@ extern const uint8_t PROGMEM digital_pin_to_timer[];
 void setup_timers();
 bool isDoubleBondedActive(uint8_t pin);
 
-#define digitalPinToPort(pin) ( (pin < NUM_TOTAL_PINS) ? pgm_read_byte(digital_pin_to_port + pin) : NOT_A_PIN )
-#define digitalPinToBitPosition(pin) ( (pin < NUM_TOTAL_PINS) ? pgm_read_byte(digital_pin_to_bit_position + pin) : NOT_A_PIN )
-#define analogPinToBitPosition(pin) ( (pin < NUM_ANALOG_INPUTS) ? pgm_read_byte(digital_pin_to_bit_position + pin + ANALOG_INPUT_OFFSET) : NOT_A_PIN )
-#define digitalPinToBitMask(pin) ( (pin < NUM_TOTAL_PINS) ? pgm_read_byte(digital_pin_to_bit_mask + pin) : NOT_A_PIN )
-#define analogPinToBitMask(pin) ( (pin < NUM_ANALOG_INPUTS) ? pgm_read_byte(digital_pin_to_bit_mask + pin + ANALOG_INPUT_OFFSET) : NOT_A_PIN )
-#define digitalPinToTimer(pin) ( (pin < NUM_TOTAL_PINS) ? pgm_read_byte(digital_pin_to_timer + pin) : NOT_ON_TIMER )
+#define digitalPinToPort(pin) ( (pin < NUM_TOTAL_PINS) ? digital_pin_to_port[pin] : NOT_A_PIN )
+#define digitalPinToBitPosition(pin) ( (pin < NUM_TOTAL_PINS) ? digital_pin_to_bit_position[pin] : NOT_A_PIN )
+#define digitalPinToBitMask(pin) ( (pin < NUM_TOTAL_PINS) ? digital_pin_to_bit_mask[pin] : NOT_A_PIN )
+#define digitalPinToTimer(pin) ( (pin < NUM_TOTAL_PINS) ? digital_pin_to_timer[pin] : NOT_ON_TIMER )
+#define analogPinToBitPosition(pin) ( (digitalPinToAnalogInput(pin) != NOT_A_PIN) ? digital_pin_to_bit_position[pin + ANALOG_INPUT_OFFSET] : NOT_A_PIN )
+#define analogPinToBitMask(pin) ( (digitalPinToAnalogInput(pin) != NOT_A_PIN) ? digital_pin_to_bit_mask[pin + ANALOG_INPUT_OFFSET] : NOT_A_PIN )
 
 #define portToPortStruct(port) ( (port < NUM_TOTAL_PORTS) ? ((PORT_t *)&PORTA + port) : NULL)
 #define digitalPinToPortStruct(pin) ( (pin < NUM_TOTAL_PINS) ? ((PORT_t *)&PORTA + digitalPinToPort(pin)) : NULL)

--- a/variants/nona4809/pins_arduino.h
+++ b/variants/nona4809/pins_arduino.h
@@ -142,7 +142,7 @@ static const uint8_t A7 = PIN_A7;
 
 //
 
-const uint8_t PROGMEM digital_pin_to_port[] = {
+const uint8_t digital_pin_to_port[] = {
   PC, // 0 PC5/USART1_Rx
   PC, // 1 PC4/USART1_Tx
   PA, // 2 PA0
@@ -172,7 +172,7 @@ const uint8_t PROGMEM digital_pin_to_port[] = {
 };
 
 /* Use this for accessing PINnCTRL register */
-const uint8_t PROGMEM digital_pin_to_bit_position[] = {
+const uint8_t digital_pin_to_bit_position[] = {
   PIN5_bp,  // 0 PC5/USART1_Rx
   PIN4_bp,  // 1 PC4/USART1_Tx
   PIN0_bp,  // 2 PA0
@@ -202,7 +202,7 @@ const uint8_t PROGMEM digital_pin_to_bit_position[] = {
 };
 
 /* Use this for accessing PINnCTRL register */
-const uint8_t PROGMEM digital_pin_to_bit_mask[] = {
+const uint8_t digital_pin_to_bit_mask[] = {
   PIN5_bm,  // 0 PC5/USART1_Rx
   PIN4_bm,  // 1 PC4/USART1_Tx
   PIN0_bm,  // 2 PA0
@@ -231,7 +231,7 @@ const uint8_t PROGMEM digital_pin_to_bit_mask[] = {
   PIN4_bm,  // 25 PB4/USART3_Tx
 };
 
-const uint8_t PROGMEM digital_pin_to_timer[] = {
+const uint8_t digital_pin_to_timer[] = {
   NOT_ON_TIMER,  // 0 PC5/USART1_Rx
   NOT_ON_TIMER,  // 1 PC4/USART1_Tx
   NOT_ON_TIMER,  // 2 PA0
@@ -260,7 +260,7 @@ const uint8_t PROGMEM digital_pin_to_timer[] = {
   NOT_ON_TIMER,  // 25 PB4/USART3_Tx
 };
 
-const uint8_t PROGMEM analog_pin_to_channel[] = {
+const uint8_t analog_pin_to_channel[] = {
   3,
   2,
   1,
@@ -274,7 +274,7 @@ const uint8_t PROGMEM analog_pin_to_channel[] = {
 #endif
 
 extern const uint8_t analog_pin_to_channel[];
-#define digitalPinToAnalogInput(p)  ((p < ANALOG_INPUT_OFFSET) ? pgm_read_byte(analog_pin_to_channel + p) : pgm_read_byte(analog_pin_to_channel + p - ANALOG_INPUT_OFFSET) )
+#define digitalPinToAnalogInput(p)  ((p < ANALOG_INPUT_OFFSET) ? pgm_read_byte(analog_pin_to_channel + p) : analog_pin_to_channel[p - ANALOG_INPUT_OFFSET] )
 
 // These serial port names are intended to allow libraries and architecture-neutral
 // sketches to automatically default to the correct port name for a particular type

--- a/variants/uno2018/pins_arduino.h
+++ b/variants/uno2018/pins_arduino.h
@@ -163,7 +163,7 @@ static const uint8_t A5 = PIN_A5;
 
 //
 
-const uint8_t PROGMEM digital_pin_to_port[] = {
+const uint8_t digital_pin_to_port[] = {
   PC, // 0 PC5/USART1_Rx
   PC, // 1 PC4/USART1_Tx
   PA, // 2 PA0
@@ -208,7 +208,7 @@ const uint8_t PROGMEM digital_pin_to_port[] = {
 };
 
 /* Use this for accessing PINnCTRL register */
-const uint8_t PROGMEM digital_pin_to_bit_position[] = {
+const uint8_t digital_pin_to_bit_position[] = {
   PIN5_bp,  // 0 PC5/USART1_Rx
   PIN4_bp,  // 1 PC4/USART1_Tx
   PIN0_bp,  // 2 PA0
@@ -253,7 +253,7 @@ const uint8_t PROGMEM digital_pin_to_bit_position[] = {
 };
 
 /* Use this for accessing PINnCTRL register */
-const uint8_t PROGMEM digital_pin_to_bit_mask[] = {
+const uint8_t digital_pin_to_bit_mask[] = {
   PIN5_bm,  // 0 PC5/USART1_Rx
   PIN4_bm,  // 1 PC4/USART1_Tx
   PIN0_bm,  // 2 PA0
@@ -297,7 +297,7 @@ const uint8_t PROGMEM digital_pin_to_bit_mask[] = {
   PIN6_bm   // 40 PF6 RESET
 };
 
-const uint8_t PROGMEM digital_pin_to_timer[] = {
+const uint8_t digital_pin_to_timer[] = {
   NOT_ON_TIMER,  // 0 PC5/USART1_Rx
   NOT_ON_TIMER,  // 1 PC4/USART1_Tx
   NOT_ON_TIMER,  // 2 PA0


### PR DESCRIPTION
Not needed since the megaAVR-0 series have unified memory. Content is kept in progmem as long as they are defined `const`. Will close #11.