### PR TITLE
Update wiring.c

### DIFF
--- a/cores/arduino/wiring.c
+++ b/cores/arduino/wiring.c
@@ -152,18 +152,7 @@ unsigned long micros() {
 void delay(unsigned long ms)
 {
 	uint32_t start_time = micros(), delay_time = 1000*ms;
-
-	/* Calculate future time to return */
-	uint32_t return_time = start_time + delay_time;
-
-	/* If return time overflows */
-	if(return_time < delay_time){
-		/* Wait until micros overflows */
-		while(micros() > return_time);
-	}
-
-	/* Wait until return time */
-	while(micros() < return_time);
+	while(micros() - start_time < delay_time) yield();
 }
 
 /* Delay for the given number of microseconds.  Assumes a 1, 8, 12, 16, 20 or 24 MHz clock. */

--- a/cores/arduino/wiring.c
+++ b/cores/arduino/wiring.c
@@ -151,8 +151,13 @@ unsigned long micros() {
 
 void delay(unsigned long ms)
 {
-	uint32_t start_time = micros(), delay_time = 1000*ms;
-	while(micros() - start_time < delay_time) yield();
+	uint32_t start_time = micros();
+
+	while (ms > 0) {
+		while (micros() - start_time < 1000) yield();
+		--ms;
+		start_time += 1000;
+	}
 }
 
 /* Delay for the given number of microseconds.  Assumes a 1, 8, 12, 16, 20 or 24 MHz clock. */


### PR DESCRIPTION
Cyclically call yield() in delay - compatibility fix for Arduino Scheduler (and similar libs)
Correct understanding of overflow with uint32_t makes for much simpler code.