### PR TITLE
Correct size output for const variables

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -79,7 +79,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.hex
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
-recipe.size.regex=^(?:\.text|\.data|\.bootloader)\s+([0-9]+).*
+recipe.size.regex=^(?:\.text|\.data|\.rodata|\.bootloader)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.data|\.bss|\.noinit)\s+([0-9]+).*
 recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 


### PR DESCRIPTION
avr-size reports const variables in .rodata (under megaavr, since there's a unified address space, you don't need to declare const variables as PROGMEM for them to not be copied to RAM, which is awesome. 

recipe.size.regex did not check .rodata when totaling up flash usage. This would result in the reported size of the sketch not including variables that were declared const; it was thus possible to make a sketch that did not fit in the flash, but where this wasn't detected until it got to avrdude during the upload process, and avrdude dutifully reported that it was trying to write to addresses that were out of range. 

See the big discussion over here when I encountered this in megaTinyCore (and @MCUdude discovered that this happened on the official megaavr boards too) https://github.com/SpenceKonde/megaTinyCore/issues/95