### PR TITLE
Show correct compiler error message in UART0.cpp

### DIFF
--- a/cores/arduino/UART0.cpp
+++ b/cores/arduino/UART0.cpp
@@ -51,7 +51,7 @@ ISR(HWSERIAL0_DRE_VECTOR)
   Serial._tx_data_empty_irq();
 }
 #else
-#error "Don't know what the Data Received interrupt vector is called for Serial"
+#error "Don't know what the Data Register Empty interrupt vector is called for Serial"
 #endif
 
 #if defined(HWSERIAL0)


### PR DESCRIPTION
Cross checked with the files UART1 to UART3, only UART0 needs the fix.