### PR TITLE
Add CI workflows

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -21,17 +21,6 @@ jobs:
           {"fqbn": "arduino:megaavr:nona4809", "type": "nanoEvery"}
         ]
 
-        # make board type-specific customizations to the matrix jobs
-        include:
-          # Uno WiFi Rev2
-          - board:
-              type: "unoWiFiRev2"
-            additional-sketch-paths: "/github/home/Arduino/libraries/Adafruit_FONA_Library/examples/FONAtest"
-          # Nano Every
-          - board:
-              type: "nanoEvery"
-            additional-sketch-paths: "/github/home/Arduino/libraries/Adafruit_FONA_Library/examples/FONAtest"
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -104,7 +93,7 @@ jobs:
             # Overwrite the Board Manager installation with the local platform
             - source-path: "./"
               name: "arduino:megaavr"
-          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
+          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }}"
           enable-size-deltas-report: 'true'
           verbose: 'true'
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         fqbn: [
-          "arduino:megaavr:uno2018" #,
-          #"arduino:megaavr:nona4809"
+          "arduino:megaavr:uno2018",
+          "arduino:megaavr:nona4809"
         ]
 
     steps:

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,67 @@
+name: Compile Examples
+
+on: [pull_request, push]
+
+jobs:
+  compile-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        fqbn: [
+          "arduino:megaavr:uno2018" #,
+          #"arduino:megaavr:nona4809"
+        ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # The source files are in a subfolder of the ArduinoCore-API repository, so it's not possible to clone it directly to the final destination in the core
+      - name: Checkout ArduinoCore-API
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/ArduinoCore-API
+          path: extras/ArduinoCore-API
+
+      - name: Install ArduinoCore-API
+        run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"
+
+      - name: Checkout Adafruit WiFiNINA
+        uses: actions/checkout@v2
+        with:
+          repository: adafruit/WiFiNINA
+          path: libraries/WiFiNINA      
+
+      - name: Compile examples
+        uses: arduino/actions/libraries/compile-examples@master
+        with:
+          fqbn: ${{ matrix.fqbn }}
+          libraries: |
+            - name: Adafruit IO Arduino
+              version: 3.6.0
+            - name: Adafruit MQTT Library
+              version: 1.0.3
+            - name: ArduinoHttpClient
+              version: 0.4.0
+            # Don't use library manager WiFiNINA
+            #  - name: WiFiNINA
+            #  version: 1.4.0
+            - name: MegunoLink
+          platforms: |
+            # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
+            - name: "arduino:megaavr"
+            # Overwrite the Board Manager installation with the local platform
+            - source-path: "./"
+              name: "arduino:megaavr"
+          sketch-paths: "extras/AIO_LED_Pot"
+          size-report-sketch: 'AIO_LED_Pot'
+          enable-size-deltas-report: 'true'
+          verbose: 'true'
+
+      - name: Save memory usage change report as artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v1
+        with:
+          name: 'size-deltas-reports'
+          path: 'size-deltas-reports'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -50,13 +50,5 @@ jobs:
             - source-path: "./"
               name: "arduino:megaavr"
           sketch-paths: "/github/home/Arduino/libraries/Adafruit_FONA_Library/examples/FONAtest"
-          size-report-sketch: 'FONAtest'
           enable-size-deltas-report: 'true'
           verbose: 'true'
-
-      - name: Save memory usage change report as artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v1
-        with:
-          name: 'size-deltas-reports'
-          path: 'size-deltas-reports'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -109,6 +109,7 @@ jobs:
             - name: ArduinoDMX
             - name: ArduinoRS485
             - name: Arduino_OAuth
+            - name: WiFiNINA
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
             - name: "arduino:megaavr"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # libraries to install for all boards
-      UNIVERSAL_LIBRARIES: '"MFRC522" "Servo" "LiquidCrystal"'
       # sketch paths to compile (recursive) for all boards
       UNIVERSAL_SKETCH_PATHS: |
         - extras/examples
@@ -39,16 +37,15 @@ jobs:
         - ~/Arduino/libraries/Arduino_LSM9DS1/examples
         - ~/Arduino/libraries/SD/examples
         - ~/Arduino/libraries/Arduino_JSON/examples
-        - ~/Arduino/libraries/WiFi/examples
 
     strategy:
       fail-fast: false
 
       matrix:
-        board: [
-          {"fqbn": "arduino:megaavr:uno2018", "type": "unoWiFiRev2"},
-          {"fqbn": "arduino:megaavr:nona4809", "type": "nanoEvery"}
-        ]
+        fqbn:
+          - "arduino:megaavr:uno2018:mode=on"
+          - "arduino:megaavr:uno2018:mode=off"
+          - "arduino:megaavr:nona4809"
 
     steps:
       - name: Checkout repository
@@ -64,12 +61,6 @@ jobs:
       - name: Install ArduinoCore-API
         run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"
 
-      - name: Checkout Adafruit WiFiNINA
-        uses: actions/checkout@v2
-        with:
-          repository: adafruit/WiFiNINA
-          path: adafruit/WiFiNINA
-
       - name: Checkout Basic examples
         uses: actions/checkout@v2
         with:
@@ -82,7 +73,7 @@ jobs:
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master
         with:
-          fqbn: ${{ matrix.board.fqbn }}
+          fqbn: ${{ matrix.fqbn }}
           libraries: |
             - name: Adafruit IO Arduino
             - name: Adafruit MQTT Library
@@ -106,16 +97,12 @@ jobs:
             - name: Arduino_JSON
             - name: Arduino_HTS221
             - name: Firmata
-            - name: ArduinoCloudThing
             - name: Arduino_DebugUtils
             - name: Arduino_LPS22HB
             - name: ArduinoIoTCloudBearSSL
             - name: ArduinoDMX
             - name: ArduinoRS485
             - name: Arduino_OAuth
-            - name: WiFi
-            - name: Bridge
-            - name: Temboo
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
             - name: "arduino:megaavr"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -105,5 +105,12 @@ jobs:
             - source-path: "./"
               name: "arduino:megaavr"
           sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
-          enable-size-deltas-report: 'false'
+          enable-size-deltas-report: 'true'
           verbose: 'true'
+
+      - name: Save memory usage change report as artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v1
+        with:
+          name: 'size-deltas-reports'
+          path: 'size-deltas-reports'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -34,26 +34,26 @@ jobs:
         - ~/Arduino/libraries/LiquidCrystal/examples
         - ~/Arduino/libraries/MFRC522/examples
         - ~/Arduino/libraries/Ethernet/examples
+        - ~/Arduino/libraries/Adafruit_MQTT_Library/examples/mqtt_ethernet
+        - ~/Arduino/libraries/ArduinoBearSSL/examples/SHA1
+        - ~/Arduino/libraries/ArduinoBearSSL/examples/SHA256
         - ~/Arduino/libraries/Arduino_LSM9DS1/examples
         - ~/Arduino/libraries/SD/examples
         - ~/Arduino/libraries/Arduino_JSON/examples
-        - ~/Arduino/libraries/Adafruit_IO_Arduino/examples
-        - ~/Arduino/libraries/Adafruit_MQTT_Library/examples
-        - ~/Arduino/libraries/ArduinoHttpClient/examples
-        - ~/Arduino/libraries/ArduinoBearSSL/examples
-        - ~/Arduino/libraries/NTPClient/examples
-        - ~/Arduino/libraries/TFT/examples
-        - ~/Arduino/libraries/ArduinoMqttClient/examples
+        - ~/Arduino/libraries/TFT/examples/Arduino/TFTBitmapLogo
+        - ~/Arduino/libraries/TFT/examples/Arduino/TFTColorPicker
+        - ~/Arduino/libraries/TFT/examples/Arduino/TFTDisplayText
+        - ~/Arduino/libraries/TFT/examples/Arduino/TFTEtchASketch
+        - ~/Arduino/libraries/TFT/examples/Arduino/TFTGraph
+        - ~/Arduino/libraries/TFT/examples/Arduino/TFTPong
         - ~/Arduino/libraries/Arduino_CRC32/examples
         - ~/Arduino/libraries/Arduino_LSM6DS3/examples
         - ~/Arduino/libraries/Stepper/examples
         - ~/Arduino/libraries/Arduino_HTS221/examples
-        - ~/Arduino/libraries/Firmata/examples
         - ~/Arduino/libraries/Arduino_DebugUtils/examples
         - ~/Arduino/libraries/Arduino_LPS22HB/examples
         - ~/Arduino/libraries/ArduinoDMX/examples
         - ~/Arduino/libraries/ArduinoRS485/examples
-        - ~/Arduino/libraries/Arduino_OAuth/examples
 
     strategy:
       fail-fast: false
@@ -72,10 +72,12 @@ jobs:
               type: "UnoWiFiRev2"
             additional-sketch-paths: |
               - ~/Arduino/libraries/WiFiNINA/examples
+              - ~/Arduino/libraries/ArduinoMqttClient/examples
+              - ~/Arduino/libraries/Arduino_OAuth/examples/Tweeter
           # Nano Every
           - board:
               type: "NanoEvery"
-            additional-sketch-paths: ''
+            additional-sketch-paths:
 
     steps:
       - name: Checkout repository
@@ -110,16 +112,13 @@ jobs:
         with:
           fqbn: ${{ matrix.board.fqbn }}
           libraries: |
-            - name: Adafruit IO Arduino
             - name: Adafruit MQTT Library
-            - name: ArduinoHttpClient
             - name: Servo
             - name: LiquidCrystal
             - name: MFRC522
             - name: Ethernet
             - name: ArduinoBearSSL
             - name: Arduino_LSM9DS1
-            - name: NTPClient
             - name: TFT
             - name: ArduinoMqttClient
             - name: Arduino_CRC32
@@ -128,7 +127,6 @@ jobs:
             - name: SD
             - name: Arduino_JSON
             - name: Arduino_HTS221
-            - name: Firmata
             - name: Arduino_DebugUtils
             - name: Arduino_LPS22HB
             - name: ArduinoDMX

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -98,8 +98,7 @@ jobs:
           verbose: 'true'
 
       - name: Save memory usage change report as artifact
-        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v1
         with:
-          name: 'size-deltas-reports'
-          path: 'size-deltas-reports'
+          name: size-deltas-reports
+          path: size-deltas-reports

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -68,7 +68,13 @@ jobs:
           path: extras
 
       - name: Delete incompatible examples
-        run: rm -r "$GITHUB_WORKSPACE/extras/examples/09.USB" && rm -r "$GITHUB_WORKSPACE/extras/examples/10.StarterKit_BasicKit/p11_CrystalBall" && rm -r "$GITHUB_WORKSPACE/extras/examples/10.StarterKit_BasicKit/p13_TouchSensorLamp"
+        run: |
+          # These boards do not support native USB
+          rm -r "$GITHUB_WORKSPACE/extras/examples/09.USB"
+          # The next command can be removed after the core integration with ArduinoCore-API
+          rm -r "$GITHUB_WORKSPACE/extras/examples/10.StarterKit_BasicKit/p11_CrystalBall"
+          # CapacitiveSensor library does not support megaAVR core yet
+          rm -r "$GITHUB_WORKSPACE/extras/examples/10.StarterKit_BasicKit/p13_TouchSensorLamp"
 
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -34,21 +34,14 @@ jobs:
           path: libraries/WiFiNINA      
 
       - name: Compile examples
-        uses: per1234/actions/libraries/compile-examples@9acb47abcea28afced4d549585b347668eb03eac
+        uses: arduino/actions/libraries/compile-examples@master
         with:
           fqbn: ${{ matrix.fqbn }}
           libraries: |
             - name: Adafruit IO Arduino
-              version: 3.6.0
             - name: Adafruit MQTT Library
-              version: 1.0.3
             - name: ArduinoHttpClient
-              version: 0.4.0
             - name: Adafruit FONA Library
-              version: 1.3.6
-            # Don't use library manager WiFiNINA
-            #  - name: WiFiNINA
-            #  version: 1.4.0
             - name: MegunoLink
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -8,9 +8,9 @@ jobs:
 
     env:
       # libraries to install for all boards
-      UNIVERSAL_LIBRARIES: '"MFRC522" "Servo"'
+      UNIVERSAL_LIBRARIES: '"MFRC522" "Servo" "LiquidCrystal"'
       # sketch paths to compile (recursive) for all boards
-      UNIVERSAL_SKETCH_PATHS: '"extras/examples" "libraries/Wire" "libraries/SPI" "libraries/SoftwareSerial" "libraries/EEPROM"'
+      UNIVERSAL_SKETCH_PATHS: '"extras/examples" "libraries/Wire" "libraries/SPI" "libraries/SoftwareSerial" "libraries/EEPROM" "~/Arduino/libraries/Servo/examples" "~/Arduino/libraries/LiquidCrystal/examples" "~/Arduino/libraries/MFRC522/examples" "~/Arduino/libraries/Ethernet/examples" "~/Arduino/libraries/Arduino_LSM9DS1/examples" "~/Arduino/libraries/SD/examples" "~/Arduino/libraries/Arduino_JSON/examples" "~/Arduino/libraries/WiFi/examples"'
 
     strategy:
       fail-fast: false
@@ -72,6 +72,32 @@ jobs:
             - name: Adafruit FONA Library
             - name: MegunoLink
             - name: Servo
+            - name: LiquidCrystal
+            - name: MFRC522
+            - name: Ethernet
+            - name: ArduinoBearSSL
+            - name: Arduino_LSM9DS1
+            - name: ArduinoHttpClient
+            - name: NTPClient
+            - name: TFT
+            - name: ArduinoMqttClient
+            - name: Arduino_CRC32
+            - name: Arduino_LSM6DS3
+            - name: Stepper
+            - name: SD
+            - name: Arduino_JSON
+            - name: Arduino_HTS221
+            - name: Firmata
+            - name: ArduinoCloudThing
+            - name: Arduino_DebugUtils
+            - name: Arduino_LPS22HB
+            - name: ArduinoIoTCloudBearSSL
+            - name: ArduinoDMX
+            - name: ArduinoRS485
+            - name: Arduino_OAuth
+            - name: WiFi
+            - name: Bridge
+            - name: Temboo
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
             - name: "arduino:megaavr"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -10,7 +10,20 @@ jobs:
       # libraries to install for all boards
       UNIVERSAL_LIBRARIES: '"MFRC522" "Servo" "LiquidCrystal"'
       # sketch paths to compile (recursive) for all boards
-      UNIVERSAL_SKETCH_PATHS: '"extras/examples" "libraries/Wire" "libraries/SPI" "libraries/SoftwareSerial" "libraries/EEPROM" "~/Arduino/libraries/Servo/examples" "~/Arduino/libraries/LiquidCrystal/examples" "~/Arduino/libraries/MFRC522/examples" "~/Arduino/libraries/Ethernet/examples" "~/Arduino/libraries/Arduino_LSM9DS1/examples" "~/Arduino/libraries/SD/examples" "~/Arduino/libraries/Arduino_JSON/examples" "~/Arduino/libraries/WiFi/examples"'
+      UNIVERSAL_SKETCH_PATHS: |
+        - extras/examples
+        - libraries/Wire
+        - libraries/SPI
+        - libraries/SoftwareSerial
+        - libraries/EEPROM
+        - ~/Arduino/libraries/Servo/examples
+        - ~/Arduino/libraries/LiquidCrystal/examples
+        - ~/Arduino/libraries/MFRC522/examples
+        - ~/Arduino/libraries/Ethernet/examples
+        - ~/Arduino/libraries/Arduino_LSM9DS1/examples
+        - ~/Arduino/libraries/SD/examples
+        - ~/Arduino/libraries/Arduino_JSON/examples
+        - ~/Arduino/libraries/WiFi/examples
 
     strategy:
       fail-fast: false

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -34,7 +34,7 @@ jobs:
           path: libraries/WiFiNINA      
 
       - name: Compile examples
-        uses: arduino/actions/libraries/compile-examples@master
+        uses: per1234/actions/libraries/compile-examples@9acb47abcea28afced4d549585b347668eb03eac
         with:
           fqbn: ${{ matrix.fqbn }}
           libraries: |
@@ -44,6 +44,8 @@ jobs:
               version: 1.0.3
             - name: ArduinoHttpClient
               version: 0.4.0
+            - name: Adafruit FONA Library
+              version: 1.3.6
             # Don't use library manager WiFiNINA
             #  - name: WiFiNINA
             #  version: 1.4.0
@@ -54,8 +56,8 @@ jobs:
             # Overwrite the Board Manager installation with the local platform
             - source-path: "./"
               name: "arduino:megaavr"
-          sketch-paths: "extras/AIO_LED_Pot"
-          size-report-sketch: 'AIO_LED_Pot'
+          sketch-paths: "/github/home/Arduino/libraries/Adafruit_FONA_Library/examples/FONAtest"
+          size-report-sketch: 'FONAtest'
           enable-size-deltas-report: 'true'
           verbose: 'true'
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -37,6 +37,24 @@ jobs:
         - ~/Arduino/libraries/Arduino_LSM9DS1/examples
         - ~/Arduino/libraries/SD/examples
         - ~/Arduino/libraries/Arduino_JSON/examples
+        - ~/Arduino/libraries/Adafruit_IO_Arduino/examples
+        - ~/Arduino/libraries/Adafruit_MQTT_Library/examples
+        - ~/Arduino/libraries/ArduinoHttpClient/examples
+        - ~/Arduino/libraries/ArduinoBearSSL/examples
+        - ~/Arduino/libraries/NTPClient/examples
+        - ~/Arduino/libraries/TFT/examples
+        - ~/Arduino/libraries/ArduinoMqttClient/examples
+        - ~/Arduino/libraries/Arduino_CRC32/examples
+        - ~/Arduino/libraries/Arduino_LSM6DS3/examples
+        - ~/Arduino/libraries/Stepper/examples
+        - ~/Arduino/libraries/Arduino_HTS221/examples
+        - ~/Arduino/libraries/Firmata/examples
+        - ~/Arduino/libraries/Arduino_DebugUtils/examples
+        - ~/Arduino/libraries/Arduino_LPS22HB/examples
+        - ~/Arduino/libraries/ArduinoDMX/examples
+        - ~/Arduino/libraries/ArduinoRS485/examples
+        - ~/Arduino/libraries/Arduino_OAuth/examples
+
     strategy:
       fail-fast: false
 
@@ -95,15 +113,12 @@ jobs:
             - name: Adafruit IO Arduino
             - name: Adafruit MQTT Library
             - name: ArduinoHttpClient
-            - name: Adafruit FONA Library
-            - name: MegunoLink
             - name: Servo
             - name: LiquidCrystal
             - name: MFRC522
             - name: Ethernet
             - name: ArduinoBearSSL
             - name: Arduino_LSM9DS1
-            - name: ArduinoHttpClient
             - name: NTPClient
             - name: TFT
             - name: ArduinoMqttClient
@@ -116,7 +131,6 @@ jobs:
             - name: Firmata
             - name: Arduino_DebugUtils
             - name: Arduino_LPS22HB
-            - name: ArduinoIoTCloudBearSSL
             - name: ArduinoDMX
             - name: ArduinoRS485
             - name: Arduino_OAuth

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -8,7 +8,7 @@ jobs:
 
     env:
       # libraries to install for all boards
-      UNIVERSAL_LIBRARIES: "MFRC522"
+      UNIVERSAL_LIBRARIES: '"MFRC522" "Servo"'
       # sketch paths to compile (recursive) for all boards
       UNIVERSAL_SKETCH_PATHS: '"extras/examples" "libraries/Wire" "libraries/SPI" "libraries/SoftwareSerial" "libraries/EEPROM"'
 
@@ -56,7 +56,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: arduino/arduino-examples
-          path: extras/examples
+          path: extras
+
+      - name: Delete incompatible examples
+        run: rm -r "$GITHUB_WORKSPACE/extras/examples/09.USB" && rm -r "$GITHUB_WORKSPACE/extras/examples/10.StarterKit_BasicKit/p11_CrystalBall" && rm -r "$GITHUB_WORKSPACE/extras/examples/10.StarterKit_BasicKit/p13_TouchSensorLamp"
 
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master
@@ -68,6 +71,7 @@ jobs:
             - name: ArduinoHttpClient
             - name: Adafruit FONA Library
             - name: MegunoLink
+            - name: Servo
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
             - name: "arduino:megaavr"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,6 +1,22 @@
 name: Compile Examples
 
-on: [pull_request, push]
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "cores/**"
+      - "libraries/**"
+      - "variants/**"
+      - "boards.txt"
+      - "platform.txt"
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "cores/**"
+      - "libraries/**"
+      - "variants/**"
+      - "boards.txt"
+      - "platform.txt"
 
 jobs:
   compile-test:

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -37,15 +37,27 @@ jobs:
         - ~/Arduino/libraries/Arduino_LSM9DS1/examples
         - ~/Arduino/libraries/SD/examples
         - ~/Arduino/libraries/Arduino_JSON/examples
-
     strategy:
       fail-fast: false
 
       matrix:
-        fqbn:
-          - "arduino:megaavr:uno2018:mode=on"
-          - "arduino:megaavr:uno2018:mode=off"
-          - "arduino:megaavr:nona4809"
+        board: [
+          {"fqbn": "arduino:megaavr:uno2018:mode=on", "type": "UnoWiFiRev2"},
+          {"fqbn": "arduino:megaavr:uno2018:mode=off", "type": "UnoWiFiRev2"},
+          {"fqbn": "arduino:megaavr:nona4809", "type": "NanoEvery"}
+        ]
+
+        # make board type-specific customizations to the matrix jobs
+        include:
+          # Uno WiFi Rev2
+          - board:
+              type: "UnoWiFiRev2"
+            additional-sketch-paths: |
+              - ~/Arduino/libraries/WiFiNINA/examples
+          # Nano Every
+          - board:
+              type: "NanoEvery"
+            additional-sketch-paths: ''
 
     steps:
       - name: Checkout repository
@@ -75,11 +87,10 @@ jobs:
           rm -r "$GITHUB_WORKSPACE/extras/examples/10.StarterKit_BasicKit/p11_CrystalBall"
           # CapacitiveSensor library does not support megaAVR core yet
           rm -r "$GITHUB_WORKSPACE/extras/examples/10.StarterKit_BasicKit/p13_TouchSensorLamp"
-
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master
         with:
-          fqbn: ${{ matrix.fqbn }}
+          fqbn: ${{ matrix.board.fqbn }}
           libraries: |
             - name: Adafruit IO Arduino
             - name: Adafruit MQTT Library
@@ -116,8 +127,10 @@ jobs:
             # Overwrite the Board Manager installation with the local platform
             - source-path: "./"
               name: "arduino:megaavr"
-          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }}"
-          enable-size-deltas-report: 'true'
+          sketch-paths: |
+            ${{ env.UNIVERSAL_SKETCH_PATHS }}
+            ${{ matrix.additional-sketch-paths }}
+          enable-deltas-report: 'true'
           verbose: 'true'
 
       - name: Save memory usage change report as artifact

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -6,12 +6,31 @@ jobs:
   compile-test:
     runs-on: ubuntu-latest
 
+    env:
+      # libraries to install for all boards
+      UNIVERSAL_LIBRARIES: "MFRC522"
+      # sketch paths to compile (recursive) for all boards
+      UNIVERSAL_SKETCH_PATHS: '"extras/examples" "libraries/Wire" "libraries/SPI" "libraries/SoftwareSerial" "libraries/EEPROM"'
+
     strategy:
+      fail-fast: false
+
       matrix:
-        fqbn: [
-          "arduino:megaavr:uno2018",
-          "arduino:megaavr:nona4809"
+        board: [
+          {"fqbn": "arduino:megaavr:uno2018", "type": "unoWiFiRev2"},
+          {"fqbn": "arduino:megaavr:nona4809", "type": "nanoEvery"}
         ]
+
+        # make board type-specific customizations to the matrix jobs
+        include:
+          # Uno WiFi Rev2
+          - board:
+              type: "unoWiFiRev2"
+            additional-sketch-paths: "/github/home/Arduino/libraries/Adafruit_FONA_Library/examples/FONAtest"
+          # Nano Every
+          - board:
+              type: "nanoEvery"
+            additional-sketch-paths: "/github/home/Arduino/libraries/Adafruit_FONA_Library/examples/FONAtest"
 
     steps:
       - name: Checkout repository
@@ -31,12 +50,18 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: adafruit/WiFiNINA
-          path: libraries/WiFiNINA      
+          path: adafruit/WiFiNINA
+
+      - name: Checkout Basic examples
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/arduino-examples
+          path: extras/examples
 
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master
         with:
-          fqbn: ${{ matrix.fqbn }}
+          fqbn: ${{ matrix.board.fqbn }}
           libraries: |
             - name: Adafruit IO Arduino
             - name: Adafruit MQTT Library
@@ -49,6 +74,6 @@ jobs:
             # Overwrite the Board Manager installation with the local platform
             - source-path: "./"
               name: "arduino:megaavr"
-          sketch-paths: "/github/home/Arduino/libraries/Adafruit_FONA_Library/examples/FONAtest"
-          enable-size-deltas-report: 'true'
+          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
+          enable-size-deltas-report: 'false'
           verbose: 'true'

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,13 @@
+name: Report PR Size Deltas
+
+on:
+  schedule:
+    - cron:  '*/5 * * * *'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/actions/libraries/report-size-deltas@master


### PR DESCRIPTION
The `compile-examples` workflow compiles:
- internal core libraries + examples
- some of the most used libraries + related examples
- all the basic [examples](https://github.com/arduino/arduino-examples/) provided in the Arduino IDE which are compatible with the boards that use this core
Memory usage information collection is always enabled and handled by the `report-size-deltas` workflow.

With the current version of the core, the compilation of the following libraries examples will fail:
- ~/Arduino/libraries/MFRC522/examples
- ~/Arduino/libraries/Adafruit_MQTT_Library/examples/mqtt_ethernet
Their failure is due to issue #62 . Once the F macro will be fixed, the compilation of these examples will be successful.