### PR TITLE
Undefine F and shadow __FlashStringHelper

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -26,6 +26,10 @@
 #include <avr/io.h>
 #include <avr/interrupt.h>
 
+#undef F
+#define F(str) (str)
+#define __FlashStringHelper char
+
 #ifdef __cplusplus
 extern "C"{
 #endif


### PR DESCRIPTION
This PR "competes" with #82 and #85 to understand which is more convenient based on CI results.
Before running CI https://github.com/arduino/ArduinoCore-megaavr/commit/a0f6beb55e6c60fdd7baffb306d99c0844377f43 was applied so a baseline with no compilation error exists.

https://github.com/arduino/arduino-examples/commit/b94e757d7a0c50ffb32c225019197bb387978fee#r44269343 need to be addressed for this PR to compile successfully