### PR TITLE
Bugfix: wrong default I2C baud rate was set for Arduino Nano Every

### DIFF
--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -201,7 +201,7 @@ void TWI_MasterSetBaud(uint32_t frequency){
 		t_rise = 1000;
 	}
 	
-	uint32_t baud = ((F_CPU_CORRECTED/frequency) - (((F_CPU_CORRECTED*t_rise)/1000)/1000)/1000 - 10)/2;
+	uint32_t baud = (F_CPU_CORRECTED / frequency - F_CPU_CORRECTED / 1000 / 1000 * t_rise / 1000 - 10) / 2;
 	TWI0.MBAUD = (uint8_t)baud;
 
 }


### PR DESCRIPTION
This PR fixes #88.

Whenever the default baud rate was used, or a custom frequency being less than 800kHz or greater than 1,200kHz was set, the computed baud rate was incorrect due to an integer overflow.
`F_CPU_CORRECTED` is a `uint32_t` set to 16000000 for Arduino Nano Every. It gets multiplied by `t_rise` which is set to 1000, thus it overflows the numeric range for a `uint32_t`.
When using the default baud rate, `TWI0.MBAUD` was set to 73 instead of 67 which appears to be the right value.

(How can we add a unit test for this?)