### PR TITLE
Fix: Allow HardwareI2C::requestFrom to return values > 256

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -95,7 +95,7 @@ void TwoWire::setClock(uint32_t clock)
 	TWI_MasterSetBaud(clock);
 }
 
-uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {	
+size_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {	
 	if(quantity > BUFFER_LENGTH){
 		quantity = BUFFER_LENGTH;
 	}
@@ -109,17 +109,17 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool sendStop) {
 	return bytes_read;
 }
 
-uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity)
+size_t TwoWire::requestFrom(uint8_t address, size_t quantity)
 {
 	return requestFrom(address, quantity, true);
 }
 
-uint8_t TwoWire::requestFrom(int address, int quantity)
+size_t TwoWire::requestFrom(int address, int quantity)
 {
 	return requestFrom((uint8_t)address, (size_t)quantity, true);
 }
 
-uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop)
+size_t TwoWire::requestFrom(int address, int quantity, int sendStop)
 {
 	return requestFrom((uint8_t)address, (size_t)quantity, (bool)sendStop);
 }

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -58,10 +58,10 @@ class TwoWire : public HardwareI2C
     void beginTransmission(int);
     uint8_t endTransmission(void);
     uint8_t endTransmission(bool);
-    uint8_t requestFrom(uint8_t, size_t);
-    uint8_t requestFrom(uint8_t, size_t, bool);
-    uint8_t requestFrom(int, int);
-    uint8_t requestFrom(int, int, int);
+    size_t requestFrom(uint8_t, size_t);
+    size_t requestFrom(uint8_t, size_t, bool);
+    size_t requestFrom(int, int);
+    size_t requestFrom(int, int, int);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *, size_t);
     virtual int available(void);


### PR DESCRIPTION
Changing return type of `requestFrom` from `uint8_t` to `size_t` allows the function to return the correct amount of bytes read (since internally it's already a `size_t` which is downcast to a `uint8_t` upon returning it).

Merging this PR is a pre-condition for merging https://github.com/arduino/ArduinoCore-API/pull/132.

@facchinm Let's coordinate to get this done.