### PR TITLE
Fix bug in analogWrite when accessing 16 bit register

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -178,8 +178,8 @@ void analogWrite(uint8_t pin, int val)
 				// (16-bit read/write operation are non-atomic and use a temporary register)
 				savedSREG = SREG;		
 				cli();							
-				timer_B->CCMPL = timer_B->CCMPL;	// copy CCMPL into temporary register
-				timer_B->CCMPH = val;				// set CCMPH value + copy temporary register content into CCMPL
+				timer_B->CCMPL = timer_B->CCMPL;  // copy CCMPL into temporary register
+				timer_B->CCMPH = val;             // set CCMPH value + copy temporary register content into CCMPL
 				SREG = savedSREG;				
 
 				/* Enable Timer Output	*/


### PR DESCRIPTION
This fix solves bug  #91 which only affects timer B.

I also added a save/clear/restore interrupt flag sequence for timer A around the non-atomic 16-bit write operation, to avoid data corruption if an interrupt occurs when writing the 16-bit register.