### PR TITLE
Update GitHub Actions actions used in sketch compilation CI workflows

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -146,6 +146,7 @@ jobs:
             ${{ matrix.additional-sketch-paths }}
           enable-deltas-report: 'true'
           verbose: 'true'
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -54,6 +54,7 @@ jobs:
         - ~/Arduino/libraries/Arduino_LPS22HB/examples
         - ~/Arduino/libraries/ArduinoDMX/examples
         - ~/Arduino/libraries/ArduinoRS485/examples
+      SKETCHES_REPORTS_PATH: sketches-reports
 
     strategy:
       fail-fast: false
@@ -108,7 +109,7 @@ jobs:
           # CapacitiveSensor library does not support megaAVR core yet
           rm -r "$GITHUB_WORKSPACE/extras/examples/10.StarterKit_BasicKit/p13_TouchSensorLamp"
       - name: Compile examples
-        uses: arduino/actions/libraries/compile-examples@master
+        uses: arduino/compile-sketches@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fqbn: ${{ matrix.board.fqbn }}
@@ -147,7 +148,7 @@ jobs:
           verbose: 'true'
 
       - name: Save memory usage change report as artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
-          name: size-deltas-reports
-          path: size-deltas-reports
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -10,4 +10,4 @@ jobs:
 
     steps:
       - name: Comment size deltas reports to PRs
-        uses: arduino/actions/libraries/report-size-deltas@master
+        uses: arduino/report-size-deltas@v1

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -11,3 +11,6 @@ jobs:
     steps:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports


### PR DESCRIPTION
The "smoke test" sketch compilation and reporting actions have been moved to dedicated repositories. The actions hosted
at the old `arduino/actions/libraries/*` location will no longer be maintained.

Since the time the actions were migrated to the dedicated repositories, a breaking change was made to the default value of the `sketches-report-path` input, which required a change to the values of the `name` and `path` inputs of the `actions/upload-artifact` action.

Note: the "Compile Examples" workflow run for this PR is using the changes I propose here. However, the "Report PR Size Deltas" workflow runs only use the workflow from the default branch of the repository. Because this PR changes the name of the workflow artifact generated by the "Compile Examples" workflow and consumed by the "Report PR Size Deltas" workflow, there will be no size deltas report for this PR. The reports will continue as usual after this PR is merged in to the default branch.