### PR TITLE
Use established KEYWORD_TOKENTYPE for Wire keyword

### DIFF
--- a/libraries/Wire/keywords.txt
+++ b/libraries/Wire/keywords.txt
@@ -6,6 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
+Wire	KEYWORD2
+
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
@@ -17,12 +19,6 @@ endTransmission	KEYWORD2
 requestFrom	KEYWORD2
 onReceive	KEYWORD2
 onRequest	KEYWORD2
-
-#######################################
-# Instances (KEYWORD2)
-#######################################
-
-Wire	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
All the other platform bundled libraries use `KEYWORD1` for the library's global instance so this provides consistency.

Fixes (in combination with equivalent PRs in the other boards platform repos) https://github.com/arduino/Arduino/issues/8538