### PR TITLE
Patch to allow use of precompiled libraries

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -34,6 +34,7 @@ compiler.elf2hex.flags=-O ihex -R .eeprom
 compiler.elf2hex.bin.flags=-O binary -R .eeprom
 compiler.elf2hex.cmd=avr-objcopy
 compiler.ldflags=
+compiler.libraries.ldflags=
 compiler.size.cmd=avr-size
 
 # This can be overridden in boards.txt
@@ -66,7 +67,7 @@ archive_file_path={build.path}/{archive_file}
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" -lm "-Wl,-Map,{build.path}/{build.project_name}.map"
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} {compiler.c.elf.extra_flags} {compiler.ldflags} -o "{build.path}/{build.project_name}.elf" {object_files} {compiler.libraries.ldflags} "{build.path}/{archive_file}" "-L{build.path}" -lm "-Wl,-Map,{build.path}/{build.project_name}.map"
 
 ## Create output files (.eep and .hex)
 recipe.objcopy.eep.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.objcopy.eep.flags} {compiler.objcopy.eep.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"


### PR DESCRIPTION
Hi,
based on issues #100 and to allow use of precompiled libraries, I added the same patch as [https://github.com/arduino/ArduinoCore-avr/commit/bca2493a5c68ba5c0a2c6963b462d917794bfb2d](https://github.com/arduino/ArduinoCore-avr/commit/bca2493a5c68ba5c0a2c6963b462d917794bfb2d) to the platform.txt.

This patch was successfully tested with Nano Every and Uno Wifi Rev2.