### PR TITLE
Disable verbose output in sketch compilation CI logs

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -145,7 +145,6 @@ jobs:
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.additional-sketch-paths }}
           enable-deltas-report: 'true'
-          verbose: 'true'
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact


### PR DESCRIPTION
The `arduino/compile-sketches` action was previously configured for verbose output.. This option is primarily intended to be used for troubleshooting and doesn't contain any information of value for general usage.

Due to the extensive coverage of this CI workflow, the logs are massive, which makes it inconvenient for anyone to read them to identify the cause of a failure. Removing the verbose output will improve that situation