### PR TITLE
Allow users to run Every at 20 Mhz (experimental)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -86,4 +86,13 @@ nona4809.menu.mode.on.build.328emulation=-DAVR_NANO_4809_328MODE
 nona4809.menu.mode.off=None (ATMEGA4809)
 nona4809.menu.mode.off.build.328emulation=
 
+## Allow users to try out their Nano Every at 20Mhz. 
+## experiental - may (or may not) have incompabilities wr.r.t other features of megaCore.
+menu.clock=Clock Speed
+nona4809.menu.clock.16internal=16MHz (default)
+nona4809.menu.clock.16internal.build.f_cpu=16000000L
+nona4809.menu.clock.16internal.bootloader.OSCCFG=0x01
+nona4809.menu.clock.20internal=20MHz (experimental)
+nona4809.menu.clock.20internal.build.f_cpu=20000000L
+nona4809.menu.clock.20internal.bootloader.OSCCFG=0x02
 ##############################################################

--- a/boards.txt
+++ b/boards.txt
@@ -87,7 +87,7 @@ nona4809.menu.mode.off=None (ATMEGA4809)
 nona4809.menu.mode.off.build.328emulation=
 
 ## Allow users to try out their Nano Every at 20Mhz. 
-## experiental - may (or may not) have incompabilities wr.r.t other features of megaCore.
+## experiental - may (or may not) have incompabilities wr.r.t other features of megaavr core.
 menu.clock=Clock Speed
 nona4809.menu.clock.16internal=16MHz (default)
 nona4809.menu.clock.16internal.build.f_cpu=16000000L


### PR DESCRIPTION
This change allows to run Nano Every at full speed, i.e. 20Mhz. It sets the right FUSE flags and CPU frequency macros - as already suggested by several people (for example  https://forum.arduino.cc/t/clock-speed-for-nano-every/599449/7).
If I understand correctly, this may or may not work with people's projects - any way we should allow people to give it a try. After all, one strength of the arduino platform is that it's "open for hacking' ;-).