### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -148,7 +148,7 @@ jobs:
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ env.SKETCHES_REPORTS_PATH }}
           name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -147,8 +147,16 @@ jobs:
           enable-deltas-report: 'true'
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
+      # Generate unique artifact name without colon
+      - name: Generate artifact name
+        env:
+          FQBN: ${{ matrix.board.fqbn }}
+        id: artifact-namer
+        run: |
+          ARTIFACT_NAME="${{ env.SKETCHES_REPORTS_PATH }}-${FQBN//:/_}"
+          echo "name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
       - name: Save memory usage change report as artifact
         uses: actions/upload-artifact@v4
         with:
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_PATH }}-${{ matrix.board.fqbn }}
+          name: ${{ steps.artifact-namer.outputs.name }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -151,4 +151,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}-${{ matrix.board.fqbn }}

--- a/.github/workflows/compile-muxto.yml
+++ b/.github/workflows/compile-muxto.yml
@@ -70,14 +70,14 @@ jobs:
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save firmware binary as workflow artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           path: ${{ env.BINARY_OUTPUT_PATH }}/${{ env.BINARY_FILENAME }}
           name: ${{ env.BINARY_ARTIFACT_NAME }}
 
       - name: Save sketches report as workflow artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download binary artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.BINARY_ARTIFACT_NAME }}
 

--- a/.github/workflows/compile-muxto.yml
+++ b/.github/workflows/compile-muxto.yml
@@ -32,17 +32,19 @@ jobs:
         board:
           - fqbn: arduino:samd:muxto:float=default,config=enabled,clock=internal_usb,timer=timer_732Hz,bootloader=4kb,serial=two_uart,usb=cdc
             platforms: |
-              # Install MattairTech_Arduino:samd via Boards Manager for the toolchain
-              - name: MattairTech_Arduino:samd
-                source-url: https://www.mattairtech.com/software/arduino/package_MattairTech_index.json
-                # This needs to match with the version of MattairTech_Arduino:samd the Arduino fork is based on in order to get the right tool versions
-                version: 1.6.17
+              # Install Fab_SAM_Arduino:samd via Boards Manager for the toolchain
+              - name: Fab_SAM_Arduino:samd
+                source-url: https://raw.githubusercontent.com/qbolsee/ArduinoCore-fab-sam/master/json/package_Fab_SAM_index.json
+                # Originally, we installed MattairTech_Arduino:samd@1.6.17 to get the right tool versions because the Arduino fork is based on it.
+                # However, MattairTech_Arduino:samd is no longer available.
+                # So we use its successor, Fab_SAM_Arduino:samd, and modify the Arduino fork to work with 1.12.0
+                version: 1.12.0
               # Install officila samd version for compiler support
               - name: arduino:samd
               # Install the platform with MuxTO support
               - name: arduino:samd
-                source-url: https://github.com/arduino/ArduinoCore-samd.git
-                version: muxto
+                source-url: https://github.com/pazeshun/ArduinoCore-samd.git
+                version: muxto-fab-sam
 
     steps:
       - name: Set environment variables


### PR DESCRIPTION
Currently, [Compile MuxTo github action](https://github.com/arduino/ArduinoCore-megaavr/actions/workflows/compile-muxto.yml) fails (e.g., https://github.com/arduino/ArduinoCore-megaavr/actions/runs/11121101633), so we cannot follow https://github.com/arduino/ArduinoCore-megaavr/issues/103#issuecomment-1651216008.
This PR tries to fix that situation.

- `upload-artifact@v2` and `download-artifact@v2` failed because they are deprecated, so this PR upgrades them to the latest version (`v4`). The deprecation notice is here: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
  - `upload-artifact@v4` requires artifact names to be unique, so this PR fixes them
    (cf. https://github.com/simonw/shot-scraper/issues/141)
- Installing `MattairTech_Arduino:samd` failed because the link to its json (https://www.mattairtech.com/software/arduino/package_MattairTech_index.json) is broken. We have its archive (https://web.archive.org/web/20210308115824/https://www.mattairtech.com/software/arduino/package_MattairTech_index.json), but some of the indicated URLs (e.g., https://www.mattairtech.com/software/arduino/MattairTech_samd_1.6.5-mt1.zip) are not archived:
  <http://web.archive.org/web/*/https://www.mattairtech.com/software/arduino/*>
  so we cannot install `MattairTech_Arduino:samd` via the archived json.
  This PR avoids that problem by installing [Fab_SAM_Arduino:samd](https://github.com/qbolsee/ArduinoCore-fab-sam), the successor of `MattairTech_Arduino:samd`. This workaround requires [some patches to ArduinoCore-samd](https://github.com/arduino/ArduinoCore-samd/pull/722), so I'm not sure this is a good way.